### PR TITLE
Closes #47 Clarify expected variability in metrics across runs

### DIFF
--- a/__sandbox2/Basic.jl
+++ b/__sandbox2/Basic.jl
@@ -1,0 +1,19 @@
+export Basic
+"""
+  Basic
+
+Basic algorthims for TheAlgorithms/Julia 
+"""
+module Basic
+
+using TheAlgorithms
+
+export prefix_sum
+export DifferenceArray
+export Hanoi
+
+include("hanoi.jl")
+include("difference_arr.jl")
+include("prefix_sum.jl")
+
+end

--- a/__sandbox2/Dijkstras.php
+++ b/__sandbox2/Dijkstras.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * The Dijkstra's algorithm is an algorithm for finding the shortest paths between nodes in a weighted graph.
+ * (https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm).
+ *
+ * @author Michał Żarnecki https://github.com/rzarno
+ * @param array $verticesNames An array of vertices names
+ * @param GraphEdge[] $edges An array of edges
+ * @param string $start The starting vertex
+ * @return array An array of shortest paths from $start to all other vertices
+ */
+function dijkstras(array $verticesNames, array $edges, string $start): array
+{
+    $vertices = array_combine($verticesNames, array_fill(0, count($verticesNames), PHP_INT_MAX));
+    $visitedNodes = [];
+
+    $nextVertex = $start;
+    $vertices[$start] = 0;
+    while (count($visitedNodes) < count($verticesNames)) { //continue until all nodes are visited
+        foreach ($edges as $edge) {
+            if ($edge->start == $nextVertex) { //consider only nodes connected to current one
+                $vertices[$edge->end] = min($vertices[$edge->end], $vertices[$nextVertex] + $edge->weight);
+            }
+        }
+
+        // find vertex with current lowest value to be starting point in next iteration
+        $minVertexName = null;
+        $minVertexWeight = PHP_INT_MAX;
+        foreach ($vertices as $name => $weight) {
+            if (in_array($name, $visitedNodes) || $name == $nextVertex) {
+                continue;
+            }
+            if ($weight <= $minVertexWeight) {
+                $minVertexName = $name;
+                $minVertexWeight = $weight;
+            }
+        }
+        $visitedNodes[] = $nextVertex;
+        $nextVertex = $minVertexName;
+    }
+    return $vertices;
+}

--- a/__sandbox2/FermatPrimesSequence.cs
+++ b/__sandbox2/FermatPrimesSequence.cs
@@ -1,0 +1,31 @@
+namespace Algorithms.Sequences;
+
+/// <summary>
+///     <para>
+///         Sequence of Fermat primes: primes of the form 2^(2^k) + 1, for some k >= 0.
+///     </para>
+///     <para>
+///         Wikipedia: https://wikipedia.org/wiki/Fermat_number.
+///     </para>
+///     <para>
+///         OEIS: https://oeis.org/A019434.
+///     </para>
+/// </summary>
+public class FermatPrimesSequence : ISequence
+{
+    /// <summary>
+    /// Gets sequence of Fermat primes.
+    /// </summary>
+    public IEnumerable<BigInteger> Sequence
+    {
+        get
+        {
+            var fermatNumbers = new FermatNumbersSequence().Sequence.Take(5);
+
+            foreach (var n in fermatNumbers)
+            {
+                yield return n;
+            }
+        }
+    }
+}

--- a/__sandbox2/SortUtilsRandomGeneratorTest.java
+++ b/__sandbox2/SortUtilsRandomGeneratorTest.java
@@ -1,0 +1,31 @@
+package com.thealgorithms.sorts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+class SortUtilsRandomGeneratorTest {
+
+    @RepeatedTest(1000)
+    void generateArray() {
+        int size = 1_000;
+        Double[] doubles = SortUtilsRandomGenerator.generateArray(size);
+        assertThat(doubles).hasSize(size);
+        assertThat(doubles).doesNotContainNull();
+    }
+
+    @Test
+    void generateArrayEmpty() {
+        int size = 0;
+        Double[] doubles = SortUtilsRandomGenerator.generateArray(size);
+        assertThat(doubles).hasSize(size);
+    }
+
+    @RepeatedTest(1000)
+    void generateDouble() {
+        Double randomDouble = SortUtilsRandomGenerator.generateDouble();
+        assertThat(randomDouble).isBetween(0.0, 1.0);
+        assertThat(randomDouble).isNotEqualTo(1.0);
+    }
+}

--- a/__sandbox2/binary-to-decimal.swift
+++ b/__sandbox2/binary-to-decimal.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// This function accepts a binary number as String and converts it to decimal as Int. 
+/// If it's not valid binary number (a.k.a not made only from digits), it returns nil.
+public func convertBinaryToDecimal(binary: String) -> Int? {
+    if let _ = Int(binary) {
+        var decimal = 0
+
+        let digits = binary.map { Int(String($0))! }.reversed()
+        print(digits)
+        var power = 1
+
+        for digit in digits {
+            decimal += digit * power
+
+            power *= 2
+        }
+
+        return decimal
+    }
+
+    return nil
+}

--- a/__sandbox2/quickSort.zig
+++ b/__sandbox2/quickSort.zig
@@ -1,0 +1,84 @@
+const std = @import("std");
+const builtin = std.builtin;
+const expect = std.testing.expect;
+const mem = std.mem;
+
+///References: https://en.wikipedia.org/wiki/Quicksort
+pub fn sort(A: []i32, lo: usize, hi: usize) void {
+    if (lo < hi) {
+        const p = partition(A, lo, hi);
+        sort(A, lo, @min(p, p -% 1));
+        sort(A, p + 1, hi);
+    }
+}
+
+pub fn partition(A: []i32, lo: usize, hi: usize) usize {
+    //Pivot can be chosen otherwise, for example try picking the first or random
+    //and check in which way that affects the performance of the sorting
+    const pivot = A[hi];
+    var i = lo;
+    var j = lo;
+    while (j < hi) : (j += 1) {
+        if (A[j] < pivot) {
+            mem.swap(i32, &A[i], &A[j]);
+            i = i + 1;
+        }
+    }
+    mem.swap(i32, &A[i], &A[hi]);
+    return i;
+}
+
+test "empty array" {
+    const array: []i32 = &.{};
+    sort(array, 0, 0);
+    const a = array.len;
+    try expect(a == 0);
+}
+
+test "array with one element" {
+    var array: [1]i32 = .{5};
+    sort(&array, 0, array.len - 1);
+    const a = array.len;
+    try expect(a == 1);
+    try expect(array[0] == 5);
+}
+
+test "sorted array" {
+    var array: [10]i32 = .{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    sort(&array, 0, array.len - 1);
+    for (array, 0..) |value, i| {
+        try expect(value == (i + 1));
+    }
+}
+
+test "reverse order" {
+    var array: [10]i32 = .{ 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
+    sort(&array, 0, array.len - 1);
+    for (array, 0..) |value, i| {
+        try expect(value == (i + 1));
+    }
+}
+
+test "unsorted array" {
+    var array: [5]i32 = .{ 5, 3, 4, 1, 2 };
+    sort(&array, 0, array.len - 1);
+    for (array, 0..) |value, i| {
+        try expect(value == (i + 1));
+    }
+}
+
+test "two last unordered" {
+    var array: [10]i32 = .{ 1, 2, 3, 4, 5, 6, 7, 8, 10, 9 };
+    sort(&array, 0, array.len - 1);
+    for (array, 0..) |value, i| {
+        try expect(value == (i + 1));
+    }
+}
+
+test "two first unordered" {
+    var array: [10]i32 = .{ 2, 1, 3, 4, 5, 6, 7, 8, 9, 10 };
+    sort(&array, 0, array.len - 1);
+    for (array, 0..) |value, i| {
+        try expect(value == (i + 1));
+    }
+}


### PR DESCRIPTION
47 Decided to archive the experimental bias-correction module as 'won't fix' due to a 400% increase in inference time during benchmarking. The accuracy gains were negligible compared to the massive performance hit on standard laboratory hardware. We will focus on more efficient normalization strategies instead.