### PR TITLE
Closes #89 Docs: Update loss function parameters for the TCR-sequencing module

### DIFF
--- a/__run_test7/LucasSeriesTest.java
+++ b/__run_test7/LucasSeriesTest.java
@@ -1,0 +1,158 @@
+package com.thealgorithms.maths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for {@link LucasSeries} class.
+ * Tests both recursive and iterative implementations for correctness,
+ * edge cases, and error handling.
+ */
+class LucasSeriesTest {
+
+    /**
+     * Test the first Lucas number L(1) = 2
+     */
+    @Test
+    void testFirstLucasNumber() {
+        assertEquals(2, LucasSeries.lucasSeries(1));
+        assertEquals(2, LucasSeries.lucasSeriesIteration(1));
+    }
+
+    /**
+     * Test the second Lucas number L(2) = 1
+     */
+    @Test
+    void testSecondLucasNumber() {
+        assertEquals(1, LucasSeries.lucasSeries(2));
+        assertEquals(1, LucasSeries.lucasSeriesIteration(2));
+    }
+
+    /**
+     * Test the third Lucas number L(3) = 3
+     */
+    @Test
+    void testThirdLucasNumber() {
+        assertEquals(3, LucasSeries.lucasSeries(3));
+        assertEquals(3, LucasSeries.lucasSeriesIteration(3));
+    }
+
+    /**
+     * Test the fourth Lucas number L(4) = 4
+     */
+    @Test
+    void testFourthLucasNumber() {
+        assertEquals(4, LucasSeries.lucasSeries(4));
+        assertEquals(4, LucasSeries.lucasSeriesIteration(4));
+    }
+
+    /**
+     * Test the fifth Lucas number L(5) = 7
+     */
+    @Test
+    void testFifthLucasNumber() {
+        assertEquals(7, LucasSeries.lucasSeries(5));
+        assertEquals(7, LucasSeries.lucasSeriesIteration(5));
+    }
+
+    /**
+     * Test the sixth Lucas number L(6) = 11
+     */
+    @Test
+    void testSixthLucasNumber() {
+        assertEquals(11, LucasSeries.lucasSeries(6));
+        assertEquals(11, LucasSeries.lucasSeriesIteration(6));
+    }
+
+    /**
+     * Test the seventh Lucas number L(7) = 18
+     */
+    @Test
+    void testSeventhLucasNumber() {
+        assertEquals(18, LucasSeries.lucasSeries(7));
+        assertEquals(18, LucasSeries.lucasSeriesIteration(7));
+    }
+
+    /**
+     * Test the eighth Lucas number L(8) = 29
+     */
+    @Test
+    void testEighthLucasNumber() {
+        assertEquals(29, LucasSeries.lucasSeries(8));
+        assertEquals(29, LucasSeries.lucasSeriesIteration(8));
+    }
+
+    /**
+     * Test the ninth Lucas number L(9) = 47
+     */
+    @Test
+    void testNinthLucasNumber() {
+        assertEquals(47, LucasSeries.lucasSeries(9));
+        assertEquals(47, LucasSeries.lucasSeriesIteration(9));
+    }
+
+    /**
+     * Test the tenth Lucas number L(10) = 76
+     */
+    @Test
+    void testTenthLucasNumber() {
+        assertEquals(76, LucasSeries.lucasSeries(10));
+        assertEquals(76, LucasSeries.lucasSeriesIteration(10));
+    }
+
+    /**
+     * Test the eleventh Lucas number L(11) = 123
+     */
+    @Test
+    void testEleventhLucasNumber() {
+        assertEquals(123, LucasSeries.lucasSeries(11));
+        assertEquals(123, LucasSeries.lucasSeriesIteration(11));
+    }
+
+    /**
+     * Test larger Lucas numbers to ensure correctness
+     */
+    @Test
+    void testLargerLucasNumbers() {
+        assertEquals(199, LucasSeries.lucasSeries(12));
+        assertEquals(199, LucasSeries.lucasSeriesIteration(12));
+        assertEquals(322, LucasSeries.lucasSeries(13));
+        assertEquals(322, LucasSeries.lucasSeriesIteration(13));
+        assertEquals(521, LucasSeries.lucasSeries(14));
+        assertEquals(521, LucasSeries.lucasSeriesIteration(14));
+        assertEquals(843, LucasSeries.lucasSeries(15));
+        assertEquals(843, LucasSeries.lucasSeriesIteration(15));
+    }
+
+    /**
+     * Test that both methods produce the same results
+     */
+    @Test
+    void testRecursiveAndIterativeConsistency() {
+        for (int i = 1; i <= 15; i++) {
+            assertEquals(LucasSeries.lucasSeries(i), LucasSeries.lucasSeriesIteration(i), "Mismatch at position " + i);
+        }
+    }
+
+    /**
+     * Test invalid input: zero
+     */
+    @Test
+    void testZeroInputThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> LucasSeries.lucasSeries(0));
+        assertThrows(IllegalArgumentException.class, () -> LucasSeries.lucasSeriesIteration(0));
+    }
+
+    /**
+     * Test invalid input: negative number
+     */
+    @Test
+    void testNegativeInputThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> LucasSeries.lucasSeries(-1));
+        assertThrows(IllegalArgumentException.class, () -> LucasSeries.lucasSeriesIteration(-1));
+        assertThrows(IllegalArgumentException.class, () -> LucasSeries.lucasSeries(-5));
+        assertThrows(IllegalArgumentException.class, () -> LucasSeries.lucasSeriesIteration(-5));
+    }
+}

--- a/__run_test7/kl_divergence_loss.rs
+++ b/__run_test7/kl_divergence_loss.rs
@@ -1,0 +1,37 @@
+//! # KL divergence Loss Function
+//!
+//! For a pair of actual and predicted probability distributions represented as vectors `actual` and `predicted`, the KL divergence loss is calculated as:
+//!
+//! `L = -Σ(actual[i] * ln(predicted[i]/actual[i]))` for all `i` in the range of the vectors
+//!
+//! Where `ln` is the natural logarithm function, and `Σ` denotes the summation over all elements of the vectors.
+//!
+//! ## KL divergence Loss Function Implementation
+//!
+//! This implementation takes two references to vectors of f64 values, `actual` and `predicted`, and returns the KL divergence loss between them.
+//!
+pub fn kld_loss(actual: &[f64], predicted: &[f64]) -> f64 {
+    // epsilon to handle if any of the elements are zero
+    let eps = 0.00001f64;
+    let loss: f64 = actual
+        .iter()
+        .zip(predicted.iter())
+        .map(|(&a, &p)| (a + eps) * ((a + eps) / (p + eps)).ln())
+        .sum();
+    loss
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kld_loss() {
+        let test_vector_actual = vec![1.346112, 1.337432, 1.246655];
+        let test_vector = vec![1.033836, 1.082015, 1.117323];
+        assert_eq!(
+            kld_loss(&test_vector_actual, &test_vector),
+            0.7752789394328498
+        );
+    }
+}


### PR DESCRIPTION
89 Updated the deployment guide to include the mandatory environment variables for S3-compatible object storage, specifically for the k-mer indexing service. Added a section on defining atomic-distance units for molecular simulations to resolve the Angstrom-vs-nanometer confusion. Documentation now matches v2.4.1.